### PR TITLE
Updated process generation rvet.c

### DIFF
--- a/rvet.c
+++ b/rvet.c
@@ -1,5 +1,5 @@
 /**
- * Código base (incompleto) para implementação de relógios vetoriais.
+ * Código base para implementação de relógios vetoriais.
  * Meta: implementar a interação entre três processos ilustrada na figura
  * da URL: 
  * 
@@ -18,22 +18,28 @@ typedef struct Clock {
    int p[3];
 } Clock;
 
+// outputs to the console the updated change to a given clock upon an event 
 void Clock_logging(int pid, Clock *clock){
    printf("Process: %d, Clock: (%d, %d, %d)\n", pid, clock->p[0], clock->p[1], clock->p[2]);
 }
 
+// Generates an event on a clock updating its current value by 1 unit
 void Event(int pid, Clock *clock, int logg){
    clock->p[pid]++;
+   
+   // The following condition checks whether logging of the clock is necessary
+   // when logg is non-zero (true) i.e., an Event might not necessarily change the current clock
    if (logg) {Clock_logging(pid, clock);}
 }
 
-
+// Given the id of a sender, effectively sends the message to be captured by the receiver
 void Send(int pid_send_to, Clock *clock, int pid_sender){
    Event(pid_sender, clock, 0);
    MPI_Send(&clock->p[0], 3, MPI_INT, pid_send_to, 0, MPI_COMM_WORLD);
    Clock_logging(pid_sender, clock);
 }
 
+// Given the id of a sender, sets off an event that may or may not be logged
 void Receive(int pid_receive_from, Clock *clock, int pid_receiver){
    Clock temp_clock = {{0,0,0}};
    MPI_Status status;
@@ -41,14 +47,53 @@ void Receive(int pid_receive_from, Clock *clock, int pid_receiver){
    Event(pid_receiver, clock, 0);
    
    MPI_Recv(&temp_clock.p[0], 3, MPI_INT, pid_receive_from, 0, MPI_COMM_WORLD, &status);
+   
    //Atualizar o relogio interno comparando com o relogio recebido
    for (int i = 0; i < 3; i++){
       clock->p[i] = (temp_clock.p[i] > clock->p[i]) ? temp_clock.p[i] : clock->p[i];
    }
    Clock_logging(pid_receiver, clock);
 }
+// /*
+// Compacts the generation of processes
+// Defines each process according to its ranking
 
-
+void Call_process(int my_id){
+    Clock clock = {{0,0,0}};
+    
+    switch(my_id){
+        case 0:
+            Event(my_id, &clock, 1);
+            Send(1, &clock, my_id);
+            Receive(1, &clock, my_id);
+            Send(2, &clock, my_id);
+            Receive(2, &clock, my_id);
+            Send(1, &clock, my_id);
+            Event(my_id, &clock, 1);
+            break;
+        
+        case 1:
+            Send(0, &clock, my_id);
+            Receive(0, &clock, my_id);
+            Receive(0, &clock, my_id);
+            break;
+        
+        case 2:
+            Event(my_id, &clock, 1);
+            Send(0, &clock, my_id);
+            Receive(0, &clock, my_id);
+            break;
+        
+        default:
+            perror("The generated process exceeds the number of processes required!!\n");
+            printf("Bug found in source code: 404");
+            break;
+            
+            
+    }
+}
+// */ REMOVE ===============================================
+/*
 // Representa o processo de rank 0
 void process0(){
    Clock clock = {{0,0,0}};
@@ -84,6 +129,7 @@ void process2(){
    Send(0, &clock, my_id);
    Receive(0, &clock, my_id);
 }
+*/
 
 int main(void) {
    int my_rank;               
@@ -91,12 +137,17 @@ int main(void) {
    MPI_Init(NULL, NULL); 
    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank); 
 
+  // REMOVE commented processes ===============================================
+
    if (my_rank == 0) { 
-      process0();
-   } else if (my_rank == 1) {  
-      process1();
+      // process0();
+      Call_process(0);
+   } else if (my_rank == 1) {
+      // process1();
+      Call_process(1);
    } else if (my_rank == 2) {  
-      process2();
+      // process2();
+      Call_process(2);
    }
 
    /* Finaliza MPI */


### PR DESCRIPTION
A single function was used to generate all 3 process with each its ranking, instead of hard-coding a function for every process one by one. Furthermore, additional suggested changes might play in favor of better compatibility: Where process 0 is invoked, for instance -->
[...]
Send(process_id+1, &clock, my_id);
[...]
Instead of:
[...]
Send(1, &clock, my_id); 
[...]
Not sure if this would work, maybe process_id+1 should be replaced by total_clocks-1, total_clocks-2, ...  where an iterating variable within a for-loop would update these indexes. 

PS. Please, remove comments is this becomes the final change.